### PR TITLE
Use atomicState and settings as well as remove some SSDP code

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -135,7 +135,7 @@ var controller = new function () {
 
                     case '/init':
                         console.log(getTimestamp() + 'Received init request');
-                        if (payload && payload.server) {
+                        if (payload) {
                             response.writeHead(202, {
                                 'Content-Type': 'application/json'
                             });
@@ -202,7 +202,7 @@ var controller = new function () {
                 return val < 10 ? '0' + val : val;
             };
 
-        return '[' + pad(dt.getDate()) + '/' + pad(dt.getMonth()) + ' ' +
+        return '[' + pad(dt.getDate()) + '/' + pad(dt.getMonth()+1) + ' ' +
             pad(dt.getHours()) + ':' + pad(dt.getMinutes()) + ':' + pad(dt.getSeconds()) + '] ';
     }
 
@@ -214,10 +214,6 @@ var controller = new function () {
         console.log('=== === === MyQ Controller === === ===');
 
         config = {};
-
-        var ssdpServer = new node.ssdp.Server();
-        ssdpServer.addUSN('urn:schemas-upnp-org:device:MQCLocalServer:624');
-        ssdpServer.start();
 
         server = node.http.createServer(doProcessRequest);
         server.listen(42457, '0.0.0.0');

--- a/smartapps/aromka/myq-controller.src/myq-controller.groovy
+++ b/smartapps/aromka/myq-controller.src/myq-controller.groovy
@@ -65,9 +65,6 @@ def prefWelcome() {
 def prefMyQValidate() {
 
     atomicState.security = [:]
-	atomicState.localServerIp = settings.localServerIp
-	atomicState.myqUsername = settings.myqUsername
-	atomicState.myqPassword = settings.myqPassword
 
 	if (doLocalLogin()) {
         if (doMyQLogin(true, true)) {
@@ -86,7 +83,7 @@ def prefMyQValidate() {
     } else {
 	    dynamicPage(name: "prefMyQValidate",  title: "MyQ™ Integration Error") {
             section(){
-                paragraph "Sorry, your local server does not seem to respond at ${atomicState.localServerIp}."
+                paragraph "Sorry, your local server does not seem to respond at ${settings.localServerIp}."
             }
         }
     }
@@ -107,8 +104,8 @@ private doLocalLogin() {
 
     atomicState.pong = false
 
-    log.trace "Pinging local server at " + atomicState.localServerIp
-    sendLocalServerCommand atomicState.localServerIp, "ping", ""
+    log.trace "Pinging local server at " + settings.localServerIp
+    sendLocalServerCommand settings.localServerIp, "ping", ""
 
     def cnt = 50
     def pong = false
@@ -137,7 +134,7 @@ def doMyQLogin(installing, force) {
     // setup our security descriptor
     atomicState.security = [
         'securityToken': null,
-    	'enabled': !!(atomicState.myqUsername && atomicState.myqPassword),
+    	'enabled': !!(settings.myqUsername && settings.myqPassword),
         'connected': 0
     ]
 
@@ -219,7 +216,7 @@ def initialize() {
    	doMyQLogin(false, false)
 
     // initialize the local server
-    sendLocalServerCommand atomicState.localServerIp, "init", [
+    sendLocalServerCommand settings.localServerIp, "init", [
         server: getHubLanEndpoint(),
         security: atomicState.security
     ]
@@ -264,7 +261,7 @@ def lanEventHandler(evt) {
     if (parsedEvent.data && parsedEvent.data.event) {
         switch (parsedEvent.data.event) {
         	case "init":
-                sendLocalServerCommand atomicState.localServerIp, "init", [
+                sendLocalServerCommand settings.localServerIp, "init", [
                     server: getHubLanEndpoint(),
                     security: processSecurity()
                 ]

--- a/smartapps/aromka/myq-controller.src/myq-controller.groovy
+++ b/smartapps/aromka/myq-controller.src/myq-controller.groovy
@@ -151,8 +151,9 @@ def doMyQLogin(installing, force) {
     log.info "Logging in to MyQ... "
 
     // perform the login, retrieve token
+    def result = false
     try {
-        httpPost([
+        result = httpPost([
             uri: "https://myqexternal.myqdevice.com",
             path: "/api/v4/User/Validate",
             headers: [
@@ -189,7 +190,7 @@ def doMyQLogin(installing, force) {
         log.debug "API Error: $e"
     }
 
-	return false;
+	return result;
 }
 
 


### PR DESCRIPTION
This PR handles a few things if you find them useful.  I have been running it now for a couple days.

-Per ST recommendations not to mix state and atomicState this PR switches everything to atomicState.  
-Use settings values rather than store them in the state.
-Remove some SSDP code that was held over from hch.
-Add 1 to the month for the logging timestamp since getMonth is 0 based.
-return the result from the closure when logging into myQ.